### PR TITLE
Avoid naive parsing of set-cookie header.

### DIFF
--- a/lib/odoo.js
+++ b/lib/odoo.js
@@ -57,7 +57,7 @@ class Odoo {
 					protocol: config.protocol,
 					host: config.host,
 					port: config.port,
-					sid: res.headers['set-cookie'][0].split(';')[0]
+					sid: `session_id=${res.body.result.session_id}`,
 				});
 			});
 	}


### PR DESCRIPTION
Fixes cases where multiple set-cookie headers are returned (e.g., AWS
sticky sessions).